### PR TITLE
Feat: ProfileItem 도메인 생성 및 API 구현 BACK-207

### DIFF
--- a/src/main/java/com/siliconvalley/domain/item/item/application/BasicItemCreateService.java
+++ b/src/main/java/com/siliconvalley/domain/item/item/application/BasicItemCreateService.java
@@ -1,0 +1,32 @@
+package com.siliconvalley.domain.item.item.application;
+
+import com.siliconvalley.domain.item.item.dao.ItemFindDao;
+import com.siliconvalley.domain.item.myitem.domain.MyItem;
+import com.siliconvalley.domain.profile.domain.Profile;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class BasicItemCreateService {
+
+    private final ItemFindDao itemFindDao;
+
+    public MyItem createBasicAvatarItem(Profile profile) {
+        return MyItem.builder()
+                .profile(profile)
+                .itemType("avatar")
+                .item(itemFindDao.findById(1L))
+                .build();
+    }
+
+    public MyItem createBasicSubjectItem(Profile profile) {
+        return MyItem.builder()
+                .profile(profile)
+                .itemType("subject")
+                .item(itemFindDao.findById(2L))
+                .build();
+    }
+}

--- a/src/main/java/com/siliconvalley/domain/item/item/dto/AvatarItemResponse.java
+++ b/src/main/java/com/siliconvalley/domain/item/item/dto/AvatarItemResponse.java
@@ -18,6 +18,7 @@ public class AvatarItemResponse {
     public AvatarItemResponse(final Item item) {
         this.id = item.getId();
         this.itemPrice = item.getItemPrice();
+        this.hasItem = true;
         this.avatarResponse = new AvatarResponse(item.getAvatar());
     }
 

--- a/src/main/java/com/siliconvalley/domain/item/item/dto/SubjectItemResponse.java
+++ b/src/main/java/com/siliconvalley/domain/item/item/dto/SubjectItemResponse.java
@@ -18,6 +18,7 @@ public class SubjectItemResponse {
     public SubjectItemResponse(final Item item) {
         this.id = item.getId();
         this.itemPrice = item.getItemPrice();
+        this.hasItem = true;
         this.subject = new SubjectResponse(item.getSubject());
     }
 

--- a/src/main/java/com/siliconvalley/domain/item/myitem/dao/MyItemFindDao.java
+++ b/src/main/java/com/siliconvalley/domain/item/myitem/dao/MyItemFindDao.java
@@ -4,6 +4,7 @@ import com.siliconvalley.domain.item.item.domain.Item;
 import com.siliconvalley.domain.item.myitem.domain.MyItem;
 import com.siliconvalley.domain.item.myitem.dto.MyAvatarItemResponse;
 import com.siliconvalley.domain.item.myitem.dto.MySubjectItemResponse;
+import com.siliconvalley.domain.item.myitem.exception.MyItemNotFoundException;
 import com.siliconvalley.global.common.code.CommonCode;
 import com.siliconvalley.global.common.dto.Response;
 import com.siliconvalley.global.common.dto.page.PageResponse;
@@ -17,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 @Service
 @Transactional
@@ -24,6 +26,12 @@ import java.util.Objects;
 public class MyItemFindDao {
 
     private final MyItemRepository myItemRepository;
+
+    public MyItem findById(Long myItemId) {
+        Optional<MyItem> myItemOptional = myItemRepository.findById(myItemId);
+        myItemOptional.orElseThrow(() -> new MyItemNotFoundException(myItemId));
+        return myItemOptional.get();
+    }
 
     public Response getMyItemListByPage(Long profileId, Pageable pageable, String category) {
         Page<MyItem> myItemPage = myItemRepository.findByProfileIdAndItemType(profileId, category, pageable);

--- a/src/main/java/com/siliconvalley/domain/item/myitem/domain/MyItem.java
+++ b/src/main/java/com/siliconvalley/domain/item/myitem/domain/MyItem.java
@@ -2,6 +2,7 @@ package com.siliconvalley.domain.item.myitem.domain;
 
 import com.siliconvalley.domain.item.item.domain.Item;
 import com.siliconvalley.domain.profile.domain.Profile;
+import com.siliconvalley.domain.profile.domain.ProfileItem;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/siliconvalley/domain/item/myitem/exception/MyItemNotFoundException.java
+++ b/src/main/java/com/siliconvalley/domain/item/myitem/exception/MyItemNotFoundException.java
@@ -1,0 +1,9 @@
+package com.siliconvalley.domain.item.myitem.exception;
+
+import com.siliconvalley.global.error.exception.EntityNotFoundException;
+
+public class MyItemNotFoundException extends EntityNotFoundException {
+    public MyItemNotFoundException(Long id) {
+        super(id + " is not found");
+    }
+}

--- a/src/main/java/com/siliconvalley/domain/post/dto/PostDetailResponse.java
+++ b/src/main/java/com/siliconvalley/domain/post/dto/PostDetailResponse.java
@@ -1,6 +1,7 @@
 package com.siliconvalley.domain.post.dto;
 
 import com.siliconvalley.domain.post.domain.Post;
+import com.siliconvalley.domain.profile.dto.ProfileAvatarItemResponse;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,13 +13,13 @@ import java.util.List;
 public class PostDetailResponse {
     private String canvasUrl;
     private Long authorProfileId;
-    private String authorProfileImage;
+    private ProfileAvatarItemResponse authorProfileAvatar;
     private List<PostEmotionTypeInfo> postEmotionTypeInfos;
 
     public PostDetailResponse(Post post, List<PostEmotionTypeInfo> postEmotionTypeInfos){
         this.canvasUrl = post.getCanvas().getCanvas();
         this.authorProfileId = post.getCanvas().getProfile().getId();
-        this.authorProfileImage = post.getCanvas().getProfile().getProfileImage();
+        this.authorProfileAvatar = new ProfileAvatarItemResponse(post.getCanvas().getProfile().getProfileItem());
         this.postEmotionTypeInfos = postEmotionTypeInfos;
     }
 }

--- a/src/main/java/com/siliconvalley/domain/profile/api/ProfileApi.java
+++ b/src/main/java/com/siliconvalley/domain/profile/api/ProfileApi.java
@@ -3,19 +3,16 @@ package com.siliconvalley.domain.profile.api;
 import com.siliconvalley.domain.canvas.dao.CanvasFindDao;
 import com.siliconvalley.domain.canvas.service.CanvasDeleteService;
 import com.siliconvalley.domain.item.item.dao.AvatarItemFindDao;
-import com.siliconvalley.domain.item.item.dao.ItemFindDao;
 import com.siliconvalley.domain.item.item.dao.SubjectItemFindDao;
 import com.siliconvalley.domain.item.myitem.application.MyItemCreateService;
-import com.siliconvalley.domain.item.myitem.code.MyItemCode;
 import com.siliconvalley.domain.item.myitem.dao.MyItemFindDao;
 import com.siliconvalley.domain.point.application.PointManagementService;
-import com.siliconvalley.domain.point.code.PointCode;
 import com.siliconvalley.domain.profile.application.ProfileManagementService;
-import com.siliconvalley.domain.profile.code.ProfileCode;
 import com.siliconvalley.domain.profile.application.ProfilePostingService;
 import com.siliconvalley.domain.profile.dao.ProfileFindDao;
-import com.siliconvalley.domain.profile.dto.ProfileCreateOrUpdate;
-import com.siliconvalley.domain.profile.dto.ProfileResponse;
+import com.siliconvalley.domain.profile.dto.ProfileCreate;
+import com.siliconvalley.domain.profile.dto.ProfileItemUpdate;
+import com.siliconvalley.domain.profile.dto.ProfileNameUpdate;
 import com.siliconvalley.domain.record.application.RecordCreateService;
 import com.siliconvalley.domain.record.application.RecordUpdateService;
 import com.siliconvalley.domain.record.dto.RecordCreateRequest;
@@ -31,7 +28,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.parameters.P;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.*;
 
@@ -66,7 +62,7 @@ public class ProfileApi {
 
     @PostMapping
     public ResponseEntity createProfile(
-            @RequestBody @Valid final ProfileCreateOrUpdate dto,
+            @RequestBody @Valid final ProfileCreate dto,
             @AuthenticationPrincipal OAuth2User oAuth2User
     ) {
         String memberId = (String) oAuth2User.getAttributes().get("id");
@@ -80,12 +76,19 @@ public class ProfileApi {
         return ResponseEntity.status(HttpStatus.OK).body(profileFindDao.getProfileById(profileId));
     }
 
-    @PatchMapping("/{profileId}")
-    public ResponseEntity updateProfile(
+    @PatchMapping("/{profileId}/names")
+    public ResponseEntity updateProfileName(
             @PathVariable("profileId") Long profileId,
-        @RequestBody @Valid final ProfileCreateOrUpdate dto
+        @RequestBody @Valid final ProfileNameUpdate dto
     ) {
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(profileManagementService.updateProfile(profileId, dto));
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(profileManagementService.updateProfileName(profileId, dto));
+    }
+    @PatchMapping("/{profileId}/profile-items/{profileItemId}")
+    public ResponseEntity updateProfileAvatar(
+            @PathVariable("profileItemId") Long profileItemId,
+        @RequestBody @Valid final ProfileItemUpdate dto
+    ) {
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(profileManagementService.updateProfileAvatar(profileItemId,dto));
     }
 
     @DeleteMapping("/{profileId}")

--- a/src/main/java/com/siliconvalley/domain/profile/application/ProfileManagementService.java
+++ b/src/main/java/com/siliconvalley/domain/profile/application/ProfileManagementService.java
@@ -1,5 +1,6 @@
 package com.siliconvalley.domain.profile.application;
 
+import com.siliconvalley.domain.item.item.application.BasicItemCreateService;
 import com.siliconvalley.domain.item.item.dao.ItemFindDao;
 import com.siliconvalley.domain.item.myitem.application.MyItemCreateService;
 import com.siliconvalley.domain.item.myitem.dao.MyItemFindDao;
@@ -44,8 +45,8 @@ public class ProfileManagementService {
     private final ItemFindDao itemFindDao;
 
     // MyItem
-    private final MyItemRepository myItemRepository;
     private final MyItemFindDao myItemFindDao;
+    private final BasicItemCreateService basicItemCreateService;
 
     // ProfileItem
     private final ProfileItemFindDao profileItemFindDao;
@@ -54,17 +55,17 @@ public class ProfileManagementService {
         if (profileRepository.existsByProfileName(dto.getProfileName())) throw new ProfileNameDuplicateException(dto.getProfileName());
         Profile profile = dto.getProfile(memberFindDao.findById(memberId));
 
-        // 기본 아이템 제공
-        MyItem myAvatarItem = profile.buildBasicAvatarItem(itemFindDao.findById(1L));
-        MyItem mySubjectItem = profile.buildBasicSubjectItem(itemFindDao.findById(2L));
-
-        // 기본 프로필 적용
-        ProfileItem profileAvatar = dto.getProfileItem(myAvatarItem);
-
-        // 객체 연관관계 설정
-        profile.addMyItem(myAvatarItem);
-        profile.addMyItem(mySubjectItem);
-        profile.addProfileAvatar(profileAvatar);
+//        // 기본 아이템 생성
+//        MyItem myAvatarItem = basicItemCreateService.createBasicAvatarItem(profile);
+//        MyItem mySubjectItem = basicItemCreateService.createBasicSubjectItem(profile);
+//
+//        // 기본 프로필 아이템 생성
+//        ProfileItem profileAvatar = dto.getProfileItem(myAvatarItem);
+//
+//        // 객체 연관관계 설정
+//        profile.addMyItem(myAvatarItem);
+//        profile.addMyItem(mySubjectItem);
+//        profile.addProfileAvatar(profileAvatar);
         profile.addPoint(profile.buildPoint());
         profileRepository.save(profile);
 

--- a/src/main/java/com/siliconvalley/domain/profile/application/ProfileManagementService.java
+++ b/src/main/java/com/siliconvalley/domain/profile/application/ProfileManagementService.java
@@ -55,13 +55,15 @@ public class ProfileManagementService {
         Profile profile = dto.getProfile(memberFindDao.findById(memberId));
 
         // 기본 아이템 제공
-        myItemRepository.save(profile.buildBasicAvatarItem(itemFindDao.findById(1L)));
-        myItemRepository.save(profile.buildBasicSubjectItem(itemFindDao.findById(2L)));
+        MyItem myAvatarItem = profile.buildBasicAvatarItem(itemFindDao.findById(1L));
+        MyItem mySubjectItem = profile.buildBasicSubjectItem(itemFindDao.findById(2L));
 
         // 기본 프로필 적용
-        ProfileItem profileAvatar = dto.getProfileItem(myItemFindDao.findById(1L));
+        ProfileItem profileAvatar = dto.getProfileItem(myAvatarItem);
 
         // 객체 연관관계 설정
+        profile.addMyItem(myAvatarItem);
+        profile.addMyItem(mySubjectItem);
         profile.addProfileAvatar(profileAvatar);
         profile.addPoint(profile.buildPoint());
         profileRepository.save(profile);

--- a/src/main/java/com/siliconvalley/domain/profile/code/ProfileItemCode.java
+++ b/src/main/java/com/siliconvalley/domain/profile/code/ProfileItemCode.java
@@ -1,0 +1,35 @@
+package com.siliconvalley.domain.profile.code;
+
+import com.siliconvalley.global.common.code.ResponseCode;
+import org.springframework.http.HttpStatus;
+
+public enum ProfileItemCode implements ResponseCode {
+
+    PATCH_SUCCESS(204, "프로필 아바타 수정에 성공했습니다.", HttpStatus.NO_CONTENT);
+
+    private final int code;
+    private final String message;
+
+    private final HttpStatus httpStatus;
+
+    ProfileItemCode(int code, String message, HttpStatus httpStatus) {
+        this.code = code;
+        this.message = message;
+        this.httpStatus = httpStatus;
+    }
+
+    @Override
+    public int getCode() {
+        return this.code;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return this.httpStatus;
+    }
+}

--- a/src/main/java/com/siliconvalley/domain/profile/dao/ProfileItemFindDao.java
+++ b/src/main/java/com/siliconvalley/domain/profile/dao/ProfileItemFindDao.java
@@ -1,0 +1,23 @@
+package com.siliconvalley.domain.profile.dao;
+
+import com.siliconvalley.domain.profile.domain.ProfileItem;
+import com.siliconvalley.domain.profile.exception.ProfileItemNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ProfileItemFindDao {
+
+    private final ProfileItemRepository profileItemRepository;
+
+    public ProfileItem findById(Long profileItemId) {
+        Optional<ProfileItem> profileItem = profileItemRepository.findById(profileItemId);
+        profileItem.orElseThrow(() -> new ProfileItemNotFoundException(profileItemId));
+        return profileItem.get();
+    }
+}

--- a/src/main/java/com/siliconvalley/domain/profile/dao/ProfileItemRepository.java
+++ b/src/main/java/com/siliconvalley/domain/profile/dao/ProfileItemRepository.java
@@ -1,0 +1,7 @@
+package com.siliconvalley.domain.profile.dao;
+
+import com.siliconvalley.domain.profile.domain.ProfileItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProfileItemRepository extends JpaRepository<ProfileItem, Long> {
+}

--- a/src/main/java/com/siliconvalley/domain/profile/domain/Profile.java
+++ b/src/main/java/com/siliconvalley/domain/profile/domain/Profile.java
@@ -76,22 +76,6 @@ public class Profile {
         this.myItemList.add(myItem);
     }
 
-    public MyItem buildBasicAvatarItem(Item item) {
-        return MyItem.builder()
-                .profile(this)
-                .item(item)
-                .itemType("avatar")
-                .build();
-    }
-
-    public MyItem buildBasicSubjectItem(Item item) {
-        return MyItem.builder()
-                .profile(this)
-                .item(item)
-                .itemType("subject")
-                .build();
-    }
-
     public void addProfileAvatar(ProfileItem profileItem) {
         this.profileItem = profileItem;
         profileItem.addProfile(this);

--- a/src/main/java/com/siliconvalley/domain/profile/domain/Profile.java
+++ b/src/main/java/com/siliconvalley/domain/profile/domain/Profile.java
@@ -44,6 +44,9 @@ public class Profile {
     @OneToOne(mappedBy = "profile", orphanRemoval = true, fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     private Point point;
 
+    @OneToMany(mappedBy = "profile", orphanRemoval = true, fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    private List<MyItem> myItemList = new ArrayList<>();
+
     @OneToMany(mappedBy = "profile", orphanRemoval = true, fetch = FetchType.LAZY)
     private List<Record> recordList;
 
@@ -67,6 +70,10 @@ public class Profile {
         return Point.builder()
                 .point(0L)
                 .build();
+    }
+
+    public void addMyItem(MyItem myItem) {
+        this.myItemList.add(myItem);
     }
 
     public MyItem buildBasicAvatarItem(Item item) {

--- a/src/main/java/com/siliconvalley/domain/profile/domain/Profile.java
+++ b/src/main/java/com/siliconvalley/domain/profile/domain/Profile.java
@@ -1,9 +1,12 @@
 package com.siliconvalley.domain.profile.domain;
 
 import com.siliconvalley.domain.canvas.domain.Canvas;
+import com.siliconvalley.domain.item.item.domain.Item;
+import com.siliconvalley.domain.item.myitem.domain.MyItem;
 import com.siliconvalley.domain.member.domain.Member;
 import com.siliconvalley.domain.point.domain.Point;
 import com.siliconvalley.domain.post.domain.Post;
+import com.siliconvalley.domain.profile.dto.ProfileNameUpdate;
 import com.siliconvalley.domain.record.domain.Record;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -28,12 +31,12 @@ public class Profile {
     @Column(name = "pf_name",length = 10)
     private String profileName;
 
-    @Column(name = "pf_image")
-    private String profileImage;
-
     @ManyToOne
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @OneToOne(mappedBy = "profile", orphanRemoval = true, fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    private ProfileItem profileItem;
 
     @OneToMany(mappedBy = "profile", orphanRemoval = true, fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     private List<Canvas> canvasList = new ArrayList<>();
@@ -45,17 +48,17 @@ public class Profile {
     private List<Record> recordList;
 
     @Builder
-    public Profile(String profileName, String profileImage,Member member) {
+    public Profile(String profileName, Member member, ProfileItem profileItem) {
         this.profileName = profileName;
-        this.profileImage = profileImage;
         this.member = member;
+        this.profileItem = profileItem;
     }
 
     public void addCanvas(Canvas canvas){
         this.canvasList.add(canvas);
     }
 
-    public void setPoint(Point point) {
+    public void addPoint(Point point) {
         this.point = point;
         point.setProfile(this);
     }
@@ -66,10 +69,29 @@ public class Profile {
                 .build();
     }
 
-    public void updateProfile(
-            final String profileName,
-            final String profileImage) {
-        this.profileName = profileName;
-        this.profileImage = profileImage;
+    public MyItem buildBasicAvatarItem(Item item) {
+        return MyItem.builder()
+                .profile(this)
+                .item(item)
+                .itemType("avatar")
+                .build();
+    }
+
+    public MyItem buildBasicSubjectItem(Item item) {
+        return MyItem.builder()
+                .profile(this)
+                .item(item)
+                .itemType("subject")
+                .build();
+    }
+
+    public void addProfileAvatar(ProfileItem profileItem) {
+        this.profileItem = profileItem;
+        profileItem.addProfile(this);
+    }
+
+    public void updateProfileName(
+            final ProfileNameUpdate dto) {
+        this.profileName = dto.getProfileName();
     }
 }

--- a/src/main/java/com/siliconvalley/domain/profile/domain/ProfileItem.java
+++ b/src/main/java/com/siliconvalley/domain/profile/domain/ProfileItem.java
@@ -1,0 +1,43 @@
+package com.siliconvalley.domain.profile.domain;
+
+import com.siliconvalley.domain.item.myitem.domain.MyItem;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "profile_item")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProfileItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id",nullable = false, updatable = false)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "profile_id")
+    private Profile profile;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "my_item_id")
+    private MyItem myItem;
+
+    @Builder
+    public ProfileItem(Profile profile, MyItem myItem) {
+        this.profile = profile;
+        this.myItem = myItem;
+    }
+
+    public void addProfile(Profile profile) {
+        this.profile = profile;
+    }
+
+    public void updateMyItem(MyItem myItem) {
+        this.myItem = myItem;
+    }
+}

--- a/src/main/java/com/siliconvalley/domain/profile/dto/ProfileAvatarItemResponse.java
+++ b/src/main/java/com/siliconvalley/domain/profile/dto/ProfileAvatarItemResponse.java
@@ -1,0 +1,20 @@
+package com.siliconvalley.domain.profile.dto;
+
+import com.siliconvalley.domain.item.myitem.dto.MyAvatarItemResponse;
+import com.siliconvalley.domain.profile.domain.ProfileItem;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ProfileAvatarItemResponse {
+
+    private Long id;
+    private MyAvatarItemResponse myAvatarItem;
+
+    public ProfileAvatarItemResponse(ProfileItem profileItem) {
+        this.id = profileItem.getId();
+        this.myAvatarItem = new MyAvatarItemResponse(profileItem.getMyItem());
+    }
+}

--- a/src/main/java/com/siliconvalley/domain/profile/dto/ProfileCreate.java
+++ b/src/main/java/com/siliconvalley/domain/profile/dto/ProfileCreate.java
@@ -1,7 +1,9 @@
 package com.siliconvalley.domain.profile.dto;
 
+import com.siliconvalley.domain.item.myitem.domain.MyItem;
 import com.siliconvalley.domain.member.domain.Member;
 import com.siliconvalley.domain.profile.domain.Profile;
+import com.siliconvalley.domain.profile.domain.ProfileItem;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,24 +12,25 @@ import javax.validation.Valid;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class ProfileCreateOrUpdate {
+public class ProfileCreate {
 
     @Valid
     private String profileName;
 
-    @Valid
-    private String profileImage;
-
-    ProfileCreateOrUpdate(@Valid String profileName, @Valid String profileImage) {
+    ProfileCreate(@Valid String profileName, @Valid Long myItemId) {
         this.profileName = profileName;
-        this.profileImage = profileImage;
     }
 
-    public Profile toEntity(final Member member) {
+    public Profile getProfile(final Member member) {
         return Profile.builder()
                 .profileName(profileName)
-                .profileImage(profileImage)
                 .member(member)
+                .build();
+    }
+
+    public ProfileItem getProfileItem(final MyItem myItem) {
+        return ProfileItem.builder()
+                .myItem(myItem)
                 .build();
     }
 }

--- a/src/main/java/com/siliconvalley/domain/profile/dto/ProfileItemUpdate.java
+++ b/src/main/java/com/siliconvalley/domain/profile/dto/ProfileItemUpdate.java
@@ -1,0 +1,19 @@
+package com.siliconvalley.domain.profile.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.Valid;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ProfileItemUpdate {
+
+    @Valid
+    private Long myItemId;
+
+    ProfileItemUpdate(Long myItemId) {
+        this.myItemId = myItemId;
+    }
+}

--- a/src/main/java/com/siliconvalley/domain/profile/dto/ProfileNameUpdate.java
+++ b/src/main/java/com/siliconvalley/domain/profile/dto/ProfileNameUpdate.java
@@ -1,0 +1,19 @@
+package com.siliconvalley.domain.profile.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.Valid;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ProfileNameUpdate {
+
+    @Valid
+    private String profileName;
+
+    ProfileNameUpdate(@Valid String profileName){
+        this.profileName = profileName;
+    }
+}

--- a/src/main/java/com/siliconvalley/domain/profile/dto/ProfileResponse.java
+++ b/src/main/java/com/siliconvalley/domain/profile/dto/ProfileResponse.java
@@ -12,13 +12,13 @@ public class ProfileResponse {
 
     private Long id;
     private String profileName;
-    private String profileImage;
     private MemberResponse member;
+    private ProfileAvatarItemResponse profileAvatar;
 
     public ProfileResponse(final Profile profile) {
         this.id = profile.getId();
         this.profileName = profile.getProfileName();
-        this.profileImage = profile.getProfileImage();
         this.member = new MemberResponse(profile.getMember());
+        this.profileAvatar = new ProfileAvatarItemResponse(profile.getProfileItem());
     }
 }

--- a/src/main/java/com/siliconvalley/domain/profile/exception/ProfileItemNotFoundException.java
+++ b/src/main/java/com/siliconvalley/domain/profile/exception/ProfileItemNotFoundException.java
@@ -1,0 +1,9 @@
+package com.siliconvalley.domain.profile.exception;
+
+import com.siliconvalley.global.error.exception.EntityNotFoundException;
+
+public class ProfileItemNotFoundException extends EntityNotFoundException {
+    public ProfileItemNotFoundException(Long id) {
+        super(id + " is not found");
+    }
+}


### PR DESCRIPTION
- Profile 생성시 기본 AvatarItem 및 기본 SubjectItem MyItem으로 제공
- Profile 생성시 기본 AvatarItem으로 프로필 사진 설정
- ProfileResponse에 ProfileAvatarItemResponse 필드 추가
- 기존 Profile Update API 하나를 ProfileNameUpdate와 ProfileItemUpdate API 2개로 분리