### PR TITLE
Feat: 스테이지 기록 생성 시 Google Vision API를 통해 그림 평가하도록 수정 BACK-269

### DIFF
--- a/src/main/java/com/siliconvalley/domain/profile/api/ProfileApi.java
+++ b/src/main/java/com/siliconvalley/domain/profile/api/ProfileApi.java
@@ -232,12 +232,12 @@ public class ProfileApi {
      * **/
 
     @PostMapping("/{profileId}/stages/{stageId}/record")
-    public ResponseEntity createRecord(
+    public ResponseEntity evaluateCanvasAndcreateRecord(
             @PathVariable(name = "profileId") Long profileId,
             @PathVariable(name = "stageId") Long stageId,
             @RequestBody RecordCreateRequest dto
             ) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(recordCreateService.createRecord(profileId, stageId, dto));
+        return ResponseEntity.status(HttpStatus.CREATED).body(recordCreateService.evaluateCanvasAndcreateRecord(profileId, stageId, dto));
     }
 
     @GetMapping("/{profileId}/stages/records")
@@ -249,11 +249,11 @@ public class ProfileApi {
     }
 
     @PatchMapping("/{profileId}/stages/{stageId}/records/{recordId}")
-    public ResponseEntity updateRecord(
+    public ResponseEntity evaluateCanvasAndupdateRecord(
             @PathVariable(name = "recordId") Long recordId,
             @RequestBody RecordUpdateRequest dto
     ) {
-        return ResponseEntity.status(HttpStatus.OK).body(recordUpdateService.updateRecord(recordId, dto));
+        return ResponseEntity.status(HttpStatus.OK).body(recordUpdateService.evaluateCanvasAndupdateRecord(recordId, dto));
     }
 
     /**

--- a/src/main/java/com/siliconvalley/domain/record/application/RecordCreateService.java
+++ b/src/main/java/com/siliconvalley/domain/record/application/RecordCreateService.java
@@ -1,5 +1,6 @@
 package com.siliconvalley.domain.record.application;
 
+import com.siliconvalley.domain.google.service.VisionDetectingService;
 import com.siliconvalley.domain.point.application.StageRewardApp;
 import com.siliconvalley.domain.point.dto.RewardPointInfo;
 import com.siliconvalley.domain.profile.dao.ProfileFindDao;
@@ -9,9 +10,10 @@ import com.siliconvalley.domain.record.dao.RecordFindDao;
 import com.siliconvalley.domain.record.dao.RecordRepository;
 import com.siliconvalley.domain.record.domain.Record;
 import com.siliconvalley.domain.record.dto.RecordCreateRequest;
-import com.siliconvalley.domain.record.dto.RecordPostSuccessResponse;
+import com.siliconvalley.domain.record.dto.RecordResponseWithPointInfo;
 import com.siliconvalley.domain.record.exception.RecordAlreadyExist;
 import com.siliconvalley.domain.stage.dao.StageFindDao;
+import com.siliconvalley.domain.stage.domain.Score;
 import com.siliconvalley.domain.stage.domain.Stage;
 import com.siliconvalley.global.common.dto.Response;
 import lombok.RequiredArgsConstructor;
@@ -28,8 +30,9 @@ public class RecordCreateService {
     private final ProfileFindDao profileFindDao;
     private final StageFindDao stageFindDao;
     private final StageRewardApp stageRewardApp;
+    private final VisionDetectingService visionDetectingService;
 
-    public Response createRecord(Long profileId, Long stageId,RecordCreateRequest dto) {
+    public Response evaluateCanvasAndcreateRecord(Long profileId, Long stageId,RecordCreateRequest dto) {
         Profile profile = profileFindDao.findById(profileId);
         Stage stage = stageFindDao.findById(stageId);
 
@@ -37,15 +40,18 @@ public class RecordCreateService {
             throw new RecordAlreadyExist(stage.getStageNum() + "번 스테이지 기록");
         }
 
-        Record record = dto.toEntity(profile, stage);
+        Score score = visionDetectingService.calculateCanvasScore(dto.getCanvasId());
+        Record record = Record.toEntity(profile, stage, score.getScoreValue());
         recordRepository.save(record);
+
         RewardPointInfo rewardPointInfo = stageRewardApp.getStageRewardPoint(
                 profile,
                 stage.getPoint(),
                 record.getScore(),
                 0
         ); // 리워드 포인트 받기
-        return Response.of(RecordCode.CREATE_SUCCESS, new RecordPostSuccessResponse(record, rewardPointInfo));
+
+        return Response.of(RecordCode.CREATE_SUCCESS, new RecordResponseWithPointInfo(record, rewardPointInfo));
     }
 }
 

--- a/src/main/java/com/siliconvalley/domain/record/application/RecordUpdateService.java
+++ b/src/main/java/com/siliconvalley/domain/record/application/RecordUpdateService.java
@@ -1,11 +1,14 @@
 package com.siliconvalley.domain.record.application;
 
+import com.siliconvalley.domain.google.service.VisionDetectingService;
 import com.siliconvalley.domain.point.application.StageRewardApp;
 import com.siliconvalley.domain.point.dto.RewardPointInfo;
 import com.siliconvalley.domain.record.code.RecordCode;
 import com.siliconvalley.domain.record.dao.RecordFindDao;
 import com.siliconvalley.domain.record.domain.Record;
+import com.siliconvalley.domain.record.dto.RecordResponseWithPointInfo;
 import com.siliconvalley.domain.record.dto.RecordUpdateRequest;
+import com.siliconvalley.domain.stage.domain.Score;
 import com.siliconvalley.global.common.dto.Response;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,16 +21,21 @@ public class RecordUpdateService {
 
     private final RecordFindDao recordFindDao;
     private final StageRewardApp stageRewardApp;
+    private final VisionDetectingService visionDetectingService;
 
-    public Response updateRecord(Long recordId, RecordUpdateRequest dto) {
+    public Response evaluateCanvasAndupdateRecord(Long recordId, RecordUpdateRequest dto) {
         Record record = recordFindDao.findById(recordId);
+        Score score = visionDetectingService.calculateCanvasScore(dto.getCanvasId());
+
         RewardPointInfo rewardPointInfo = stageRewardApp.getStageRewardPoint(
                 record.getProfile(),
                 record.getStage().getPoint(),
-                dto.getScore(),
+                score.getScoreValue(),
                 record.getScore()
-        );
-        record.updateScore(dto.getScore());
-        return Response.of(RecordCode.UPDATE_SUCCESS, rewardPointInfo);
+        ); // 리워드 포인트 받기
+
+        record.updateScore(score.getScoreValue());
+
+        return Response.of(RecordCode.UPDATE_SUCCESS, new RecordResponseWithPointInfo(record, rewardPointInfo));
     }
 }

--- a/src/main/java/com/siliconvalley/domain/record/domain/Record.java
+++ b/src/main/java/com/siliconvalley/domain/record/domain/Record.java
@@ -38,6 +38,14 @@ public class Record {
         this.profile = profile;
     }
 
+    public static Record toEntity(Profile profile, Stage stage, int score) {
+        return Record.builder()
+                .score(score)
+                .profile(profile)
+                .stage(stage)
+                .build();
+    }
+
     public void updateScore(int score) {
         this.score = score;
     }

--- a/src/main/java/com/siliconvalley/domain/record/dto/RecordCreateRequest.java
+++ b/src/main/java/com/siliconvalley/domain/record/dto/RecordCreateRequest.java
@@ -14,19 +14,11 @@ import javax.validation.Valid;
 public class RecordCreateRequest {
 
     @Valid
-    private int score;
+    private Long canvasId;
 
     RecordCreateRequest(
-            @Valid int score
+            @Valid Long canvasId
     ) {
-        this.score = score;
-    }
-
-    public Record toEntity(Profile profile, Stage stage) {
-        return Record.builder()
-                .score(score)
-                .profile(profile)
-                .stage(stage)
-                .build();
+        this.canvasId = canvasId;
     }
 }

--- a/src/main/java/com/siliconvalley/domain/record/dto/RecordResponseWithPointInfo.java
+++ b/src/main/java/com/siliconvalley/domain/record/dto/RecordResponseWithPointInfo.java
@@ -8,13 +8,15 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class RecordPostSuccessResponse {
+public class RecordResponseWithPointInfo {
 
     private Long id;
+    private int score;
     private RewardPointInfo pointInfo;
 
-    public RecordPostSuccessResponse(Record record, RewardPointInfo rewardPointInfo) {
+    public RecordResponseWithPointInfo(Record record, RewardPointInfo rewardPointInfo) {
         this.id = record.getId();
+        this.score = record.getScore();
         this.pointInfo = rewardPointInfo;
     }
 }

--- a/src/main/java/com/siliconvalley/domain/record/dto/RecordUpdateRequest.java
+++ b/src/main/java/com/siliconvalley/domain/record/dto/RecordUpdateRequest.java
@@ -14,11 +14,11 @@ import javax.validation.Valid;
 public class RecordUpdateRequest {
 
     @Valid
-    private int score;
+    private Long canvasId;
 
     RecordUpdateRequest(
-            @Valid int score
+            @Valid Long canvasId
     ) {
-        this.score = score;
+        this.canvasId = canvasId;
     }
 }


### PR DESCRIPTION
- CreateDTO 및 UpdateDTO에서 score를 직접 받는것이 아닌 canvasId를 받도록 수정 
- 받은 canvasId로 VisionService의 calculateCanvasScore 메서드로 Score 객체 생성 
- Score 객체의 scoreValue를 통해 기록생성 및 그에 따른 리워드 포인트 지급