### PR TITLE
Fix: Canvas SSE 연결시 연결 성공 알림 보내도록 수정 BACK-266

### DIFF
--- a/src/main/java/com/siliconvalley/domain/sse/application/CanvasSseEmitterService.java
+++ b/src/main/java/com/siliconvalley/domain/sse/application/CanvasSseEmitterService.java
@@ -1,5 +1,6 @@
 package com.siliconvalley.domain.sse.application;
 
+import com.siliconvalley.domain.sse.dto.SseConnectSuccessResponse;
 import com.siliconvalley.domain.sse.repository.CanvasSseEmitterRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,6 +12,7 @@ public class CanvasSseEmitterService {
 
     private final CanvasSseEmitterRepository canvasSseEmitterRepository;
     private final CanvasSseEmitterCreater canvasSseEmitterCreater;
+    private final SseEmitterSender sseEmitterSender;
 
     public SseEmitter connect(Long profileId) {
 
@@ -19,6 +21,11 @@ public class CanvasSseEmitterService {
             canvasSseEmitterRepository.delete(profileId);
         }
         SseEmitter sseEmitter = canvasSseEmitterCreater.createEmitter(profileId);
+
+        // 연결 후 즉시 알림을 보내지 않으면 연결이 끊길 수 있으므로 연결 성공 알림 보내기
+        String id = profileId + "_" + System.currentTimeMillis();
+        sseEmitterSender.send(sseEmitter, id, new SseConnectSuccessResponse(profileId), profileId, "initial");
+
         return sseEmitter;
     }
 }


### PR DESCRIPTION
- front 요청 및 SSE 연결 안정성을 위해 연결 성공 "initial" 알림 전송하도록 수정