### PR TITLE
fix: RabbitMQ 무한 루프 수정 [BACK-273]

### DIFF
--- a/src/main/java/com/siliconvalley/domain/post/dao/PostCustomRepository.java
+++ b/src/main/java/com/siliconvalley/domain/post/dao/PostCustomRepository.java
@@ -6,7 +6,6 @@ import com.siliconvalley.domain.post.domain.QEmotion;
 import com.siliconvalley.domain.post.domain.QPost;
 import com.siliconvalley.domain.post.dto.PostRankingDto;
 import com.siliconvalley.domain.post.dto.QPostRankingDto;
-import com.siliconvalley.domain.profile.domain.QProfile;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/siliconvalley/domain/rabbitMQ/exception/MessageErrorException.java
+++ b/src/main/java/com/siliconvalley/domain/rabbitMQ/exception/MessageErrorException.java
@@ -1,0 +1,10 @@
+package com.siliconvalley.domain.rabbitMQ.exception;
+
+import com.siliconvalley.global.error.exception.BusinessException;
+import com.siliconvalley.global.error.exception.ErrorCode;
+
+public class MessageErrorException extends BusinessException {
+    public MessageErrorException(String message){
+        super(message, ErrorCode.RABBITMQ_ERROR); // 예를 들어 RABBITMQ_MESSAGE_ERROR라는 ErrorCode를 사용
+    }
+}

--- a/src/main/java/com/siliconvalley/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/siliconvalley/global/error/GlobalExceptionHandler.java
@@ -4,6 +4,8 @@ import com.siliconvalley.global.error.exception.BusinessException;
 
 import com.siliconvalley.global.error.exception.ErrorCode;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.AmqpException;
+import org.springframework.amqp.AmqpRejectAndDontRequeueException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -104,6 +106,20 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponse> handleIOException(IOException e) {
         log.error("handleIOException", e);
         final ErrorResponse response = ErrorResponse.of(ErrorCode.FILE_UPLOAD_ERROR); // 적절한 ErrorCode 값을 사용하세요
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(AmqpRejectAndDontRequeueException.class)
+    protected ResponseEntity<ErrorResponse> handleAmqpRejectAndDontRequeueException(AmqpRejectAndDontRequeueException e) {
+        log.error("handleAmqpRejectAndDontRequeueException", e);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.RABBITMQ_MESSAGE_REJECTED); // 적절한 ErrorCode를 정의하고 사용하세요
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(AmqpException.class)
+    protected ResponseEntity<ErrorResponse> handleAmqpException(AmqpException e) {
+        log.error("handleAmqpException", e);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.RABBITMQ_ERROR); // 적절한 ErrorCode를 정의하고 사용하세요
         return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 

--- a/src/main/java/com/siliconvalley/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/siliconvalley/global/error/exception/ErrorCode.java
@@ -29,7 +29,11 @@ public enum ErrorCode {
     PROFILE_NAME_DUPLICATE(400, "P001", "Profile Name Duplicate"),
 
     // Item
-    INVALID_CATEROTY(400,"I001", "Invalid category");
+    INVALID_CATEROTY(400,"I001", "Invalid category"),
+
+    // RabbitMQ
+    RABBITMQ_MESSAGE_REJECTED(400, "R001", "Rejected messaging"),
+    RABBITMQ_ERROR(400, "R002", "Message Error");
 
     private final String code;
     private final String message;


### PR DESCRIPTION

* RabbitMQ 메시지 리스너 메서드에서 메시징 처리 실패시 에러 글로벌 핸들링     
* DLQ, DLX(실패한 메시지를 넣어둘 큐 생성 및 바인딩)처리 
