### PR TITLE
feat: 모델명 - visionAPI 인식명 분리 [BACK-302]

### DIFF
--- a/src/main/java/com/siliconvalley/domain/google/service/VisionDetectingService.java
+++ b/src/main/java/com/siliconvalley/domain/google/service/VisionDetectingService.java
@@ -22,7 +22,7 @@ public class VisionDetectingService {
     public Score calculateCanvasScore(Long canvasId) {
         Canvas canvas = canvasFindDao.findById(canvasId);
         Map<String, Float> detectResult = visionService.detectObjects(canvas.getCanvas());
-        Float detectionScore = detectResult.get(canvas.getSubject().getPix2Pix().getModelName());
+        Float detectionScore = detectResult.get(canvas.getSubject().getPix2Pix().getVisionName());
 
         return Score.determineScore(detectionScore);
     }

--- a/src/main/java/com/siliconvalley/domain/item/item/api/SubjectItemApi.java
+++ b/src/main/java/com/siliconvalley/domain/item/item/api/SubjectItemApi.java
@@ -34,10 +34,12 @@ public class SubjectItemApi {
     public ResponseEntity createSubjectItem(
             @RequestParam("subjectImage") MultipartFile subjectImage,
             @RequestParam("itemPrice") Long itemPrice,
-            @RequestParam("subjectName") String subjectName
+            @RequestParam("subjectName") String subjectName,
+            @RequestParam("modelName") String modelName,
+            @RequestParam("visionName") String visionName
     ) throws IOException {
         String subjectImgUrl = s3ImageUploadService.uploadFile(subjectImage, s3PathBuildService.buildPathForItem("subject"));
-        return ResponseEntity.status(HttpStatus.CREATED).body(subjectItemCreateService.createSubjectItem(itemPrice, subjectName, subjectImgUrl));
+        return ResponseEntity.status(HttpStatus.CREATED).body(subjectItemCreateService.createSubjectItem(itemPrice, subjectName, subjectImgUrl, modelName, visionName));
     }
 
     @GetMapping

--- a/src/main/java/com/siliconvalley/domain/item/item/api/SubjectItemApi.java
+++ b/src/main/java/com/siliconvalley/domain/item/item/api/SubjectItemApi.java
@@ -3,7 +3,6 @@ package com.siliconvalley.domain.item.item.api;
 import com.siliconvalley.domain.image.service.S3ImageUploadService;
 import com.siliconvalley.domain.image.service.S3PathBuildService;
 import com.siliconvalley.domain.item.item.dao.SubjectItemFindDao;
-import com.siliconvalley.domain.item.item.dto.SubjectItemCreateRequest;
 import com.siliconvalley.domain.item.item.application.SubjectItemCreateService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -12,7 +11,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.validation.Valid;
 import java.io.IOException;
 
 @RestController

--- a/src/main/java/com/siliconvalley/domain/item/item/application/SubjectItemCreateService.java
+++ b/src/main/java/com/siliconvalley/domain/item/item/application/SubjectItemCreateService.java
@@ -7,12 +7,12 @@ import com.siliconvalley.domain.item.item.dto.ItemPostSuccessResponse;
 import com.siliconvalley.domain.item.subject.domain.Subject;
 import com.siliconvalley.domain.notification.application.NotificationPushService;
 import com.siliconvalley.domain.notification.domain.NotificationType;
+import com.siliconvalley.domain.pix2pix.dao.Pix2PixRepository;
+import com.siliconvalley.domain.pix2pix.domain.Pix2Pix;
 import com.siliconvalley.global.common.dto.Response;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.io.IOException;
 
 @Service
 @Transactional
@@ -20,14 +20,16 @@ import java.io.IOException;
 public class SubjectItemCreateService {
 
     private final ItemRepository itemRepository;
+    private final Pix2PixRepository pix2PixRepository;
     private final NotificationPushService notificationPushService;
 
-    public Response createSubjectItem(Long itemPrice, String subjectName, String subjectImgUrl) {
+    public Response createSubjectItem(Long itemPrice, String subjectName, String subjectImgUrl, String modelName, String visionName) {
 
         Item item = Item.toEntity(itemPrice);
-
+        Subject subject = Subject.toEntity(subjectName, subjectImgUrl, item);
         // Item과 Subject빌드 및 연관관계 매핑
-        item.addSubject(Subject.toEntity(subjectName, subjectImgUrl, item));
+        subject.setPix2Pix(Pix2Pix.toEntity(subject, modelName, visionName));
+        item.addSubject(subject);
 
         // Item이 저장될 때 Subject 자동 저장
         itemRepository.save(item);

--- a/src/main/java/com/siliconvalley/domain/item/item/application/SubjectItemCreateService.java
+++ b/src/main/java/com/siliconvalley/domain/item/item/application/SubjectItemCreateService.java
@@ -7,7 +7,6 @@ import com.siliconvalley.domain.item.item.dto.ItemPostSuccessResponse;
 import com.siliconvalley.domain.item.subject.domain.Subject;
 import com.siliconvalley.domain.notification.application.NotificationPushService;
 import com.siliconvalley.domain.notification.domain.NotificationType;
-import com.siliconvalley.domain.pix2pix.dao.Pix2PixRepository;
 import com.siliconvalley.domain.pix2pix.domain.Pix2Pix;
 import com.siliconvalley.global.common.dto.Response;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +19,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class SubjectItemCreateService {
 
     private final ItemRepository itemRepository;
-    private final Pix2PixRepository pix2PixRepository;
     private final NotificationPushService notificationPushService;
 
     public Response createSubjectItem(Long itemPrice, String subjectName, String subjectImgUrl, String modelName, String visionName) {

--- a/src/main/java/com/siliconvalley/domain/item/subject/domain/Subject.java
+++ b/src/main/java/com/siliconvalley/domain/item/subject/domain/Subject.java
@@ -41,10 +41,11 @@ public class Subject {
     private Pix2Pix pix2Pix;
 
     @Builder
-    public Subject(String subjectName, String subjectImage, Item item) {
+    public Subject(String subjectName, String subjectImage, Item item, Pix2Pix pix2Pix) {
         this.subjectName = subjectName;
         this.subjectImage = subjectImage;
         this.item = item;
+        this.pix2Pix = pix2Pix;
     }
 
 
@@ -56,6 +57,9 @@ public class Subject {
                 .build();
     }
 
+    public void setPix2Pix(Pix2Pix pix2Pix){
+        this.pix2Pix = pix2Pix;
+    }
     public void setItem(Item item) {
         this.item = item;
     }

--- a/src/main/java/com/siliconvalley/domain/pix2pix/domain/Pix2Pix.java
+++ b/src/main/java/com/siliconvalley/domain/pix2pix/domain/Pix2Pix.java
@@ -21,14 +21,26 @@ public class Pix2Pix {
     @Column(name = "model_name")
     private String modelName;
 
+    @Column(name = "vision_name")
+    private String visionName;
+
     @OneToOne
     @JoinColumn(name = "subject_id")
     private Subject subject;
 
     @Builder
-    public Pix2Pix(String modelName, Subject subject){
+    public Pix2Pix(String modelName, String visionName, Subject subject){
         this.modelName = modelName;
+        this.visionName = visionName;
         this.subject = subject;
+    }
+
+    public static Pix2Pix toEntity(Subject subject, String modelName, String visionName){
+        return Pix2Pix.builder()
+                .modelName(modelName)
+                .visionName(visionName)
+                .subject(subject)
+                .build();
     }
 
 }


### PR DESCRIPTION
* 모델명 - visionAPI에서 인식하는 물체명 분리
* 주제 아이템 등록시 모델도 함께 생성되도록 수정

Resolves : issue #302