### PR TITLE
fix: api 엔드포인트 오타 수정 및 메소드 파라미터 수정 [BACK-303]

### DIFF
--- a/src/main/java/com/siliconvalley/domain/canvas/controller/CanvasController.java
+++ b/src/main/java/com/siliconvalley/domain/canvas/controller/CanvasController.java
@@ -45,14 +45,14 @@ public class CanvasController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
-    @PostMapping("/demo/subejct/{subjectId}/tempId/{tempId}")
+    @PostMapping("/demo/subject/{subjectId}/tempId/{tempId}")
     public ResponseEntity<Response> convertSketchToCanvasTest(
             @RequestParam ("sketchFile") MultipartFile sketchFile,
             @PathVariable String tempId,
             @PathVariable Long subjectId
     )throws IOException{
         String sketchUrl = s3ImageUploadService.uploadFile(sketchFile, "demo");
-        Response response = canvasConvertService.convertSketchToCanvasDemo(tempId, sketchUrl, subjectId);
+        Response response = canvasConvertService.convertSketchToCanvasDemo(sketchUrl, tempId, subjectId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/siliconvalley/domain/canvas/service/CanvasConvertService.java
+++ b/src/main/java/com/siliconvalley/domain/canvas/service/CanvasConvertService.java
@@ -52,8 +52,7 @@ public class CanvasConvertService {
 
     public Response convertSketchToCanvasDemo(String sketch, String tempId, Long subjectId){
         UseModelDto dto = pix2PixFindDao.findBySubjectId(subjectId);
-        convertRequestSender.sendDemoConversionRequest(sketch, tempId, dto.getModelName());
-        return Response.of(CommonCode.GOOD_REQUEST, null);
+        return convertRequestSender.sendDemoConversionRequest(sketch, tempId, dto.getModelName());
     }
 
     public Response updateSketchAndCanvas(Long profileId, Long canvasId, String sketch){

--- a/src/test/java/com/siliconvalley/canvas/CanvasConvertTests.java
+++ b/src/test/java/com/siliconvalley/canvas/CanvasConvertTests.java
@@ -1,0 +1,94 @@
+//package com.siliconvalley.canvas;
+//
+//import com.siliconvalley.domain.canvas.dto.CanvasConvertResponse;
+//import com.siliconvalley.domain.item.subject.domain.Subject;
+//import com.siliconvalley.domain.pix2pix.domain.Pix2Pix;
+//import com.siliconvalley.domain.post.service.RankCachingService;
+//import com.siliconvalley.domain.rabbitMQ.dto.SketchConversionRequest;
+//import com.siliconvalley.domain.rabbitMQ.dto.SketchConversionResponse;
+//import com.siliconvalley.domain.rabbitMQ.service.ConvertRequestSender;
+//import com.siliconvalley.domain.rabbitMQ.service.ConvertResponseReceiver;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Test;
+//import org.junit.jupiter.api.extension.ExtendWith;
+//import org.mockito.InjectMocks;
+//import org.mockito.Mock;
+//import org.mockito.junit.jupiter.MockitoExtension;
+//import org.springframework.amqp.rabbit.core.RabbitTemplate;
+//import org.springframework.boot.test.context.SpringBootTest;
+//
+//import static org.mockito.Mockito.*;
+//
+//@SpringBootTest
+//@ExtendWith(MockitoExtension.class)
+//@DisplayName("그림 변환 테스트")
+//public class CanvasConvertTests {
+//
+//    @InjectMocks
+//    private ConvertRequestSender convertRequestSender;
+//    @InjectMocks
+//    private ConvertResponseReceiver convertResponseReceiver;
+//    @Mock
+//    private RabbitTemplate rabbitTemplate;
+//    @Mock
+//    private RankCachingService rankCachingService;  // Redis 서비스 모킹
+//
+//    @Test
+//    @DisplayName(value = "변환 요청을 알맞은 메시지 큐로 전달한다.")
+//    void 변환_메시지_전달(){
+//
+//        // given
+//        String sketchUrl = "testSketchUrl";
+//        Long canvasId = 1L;
+//        Long profileId = 1L;
+//        Subject mockSubject = mock(Subject.class);
+//
+//        Pix2Pix mockPix2Pix = mock(Pix2Pix.class);
+//        when(mockPix2Pix.getModelName()).thenReturn("testModelName");
+//
+//        // mockSubject의 getPix2Pix()가 mockPix2Pix를 반환하도록 설정합니다.
+//        when(mockSubject.getPix2Pix()).thenReturn(mockPix2Pix);
+//
+//        // Redis 서비스 호출에 대한 모킹
+//        when(rankCachingService.getTopPostThisWeek(anyLong())).thenReturn("topPost1");
+//
+//        // when
+//        convertRequestSender.sendSketchConversionRequest(sketchUrl, canvasId, profileId, mockSubject);
+//
+//        // then
+//        verify(rabbitTemplate).convertAndSend(anyString(), eq("sketch_conversion_request_queue"), any(SketchConversionRequest.class));
+//        verify(rankCachingService).getTopPostThisWeek(anyLong());
+//    }
+//
+//
+//    @Test
+//    @DisplayName(value = "메시지 큐에서 변환 응답을 수신하고 결과를 클라이언트에게 전송한다.")
+//    void 변환_메시지_수신(){
+//
+//    }
+//
+//    @Test
+//    @DisplayName(value = "데모 변환 요청을 알맞은 메시지 큐로 전달한다.")
+//    void 데모_변환_메시지_전달(){
+//
+//    }
+//
+//    @Test
+//    @DisplayName(value = "메시지 큐에서 데모 변환 응답을 수신하고 결과를 클라이언트에게 전송한다.")
+//    void 데모_변환_메시지_수신(){
+//
+//    }
+//
+//    @Test
+//    @DisplayName(value = "메시지 큐에서 변환 응답을 수신하고, 메시지 처리 과정에 오류가 발생하면 메시지를 DLQ로 반송한다.")
+//    void 변환_메시지_처리_오류(){
+//
+//    }
+//
+//    @Test
+//    @DisplayName(value = "메시지 큐에서 데모 변환 응답을 수신하고, 메시지 처리 과정에 오류가 발생하면 메시지를 DLQ로 반송한다.")
+//    void 데모_변환_메시지_처리_오류(){
+//
+//    }
+//}
+//


### PR DESCRIPTION
* 엔드포인트 오타 수정 `subejct -> subject`
* 파라미터 순서 수정 (TempId와 SketchUrl 순서가 바뀌어있었음)